### PR TITLE
update amazon sdk

### DIFF
--- a/src/AWS.MSK.Auth.csproj
+++ b/src/AWS.MSK.Auth.csproj
@@ -1,38 +1,38 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
-		<RootNamespace>AWS.MSK.Auth</RootNamespace>
-		<ImplicitUsings>enable</ImplicitUsings>
-    	<Nullable>enable</Nullable>
-		<LangVersion>10.0</LangVersion>
-		<Version>1.0.1</Version>
-		<Title>AWS MSK Signer library for IAM Authentication</Title>
-		<Description>This libary vends encoded IAM v4 signatures which can be used as IAM Auth tokens to authenticate against an MSK cluster.</Description>
-		<Authors>Amazon Web Services</Authors>
-		<Copyright>Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
-		<PackageTags>AWS;MSK;Kafka;IAM</PackageTags>
-		<PackageProjectUrl>https://github.com/aws/aws-msk-iam-sasl-signer-net</PackageProjectUrl>
-		<PackageIcon>icon.png</PackageIcon>
-		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<PackageLicenseFile>LICENSE</PackageLicenseFile>
-		<RepositoryUrl>https://github.com/aws/aws-msk-iam-sasl-signer-net</RepositoryUrl>
-		<SignAssembly>True</SignAssembly>
+    <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>AWS.MSK.Auth</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+      <Nullable>enable</Nullable>
+    <LangVersion>10.0</LangVersion>
+    <Version>1.0.1</Version>
+    <Title>AWS MSK Signer library for IAM Authentication</Title>
+    <Description>This libary vends encoded IAM v4 signatures which can be used as IAM Auth tokens to authenticate against an MSK cluster.</Description>
+    <Authors>Amazon Web Services</Authors>
+    <Copyright>Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.</Copyright>
+    <PackageTags>AWS;MSK;Kafka;IAM</PackageTags>
+    <PackageProjectUrl>https://github.com/aws/aws-msk-iam-sasl-signer-net</PackageProjectUrl>
+    <PackageIcon>icon.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <RepositoryUrl>https://github.com/aws/aws-msk-iam-sasl-signer-net</RepositoryUrl>
+    <SignAssembly>True</SignAssembly>
                 <AssemblyOriginatorKeyFile>../public.snk</AssemblyOriginatorKeyFile>
-		<Company>Amazon Web Services</Company>
-	</PropertyGroup>
+    <Company>Amazon Web Services</Company>
+  </PropertyGroup>
 
 
-  	<ItemGroup>
-		<None Include="..\LICENSE" Pack="true" PackagePath="" />
-		<None Include="..\NOTICE" Pack="true" PackagePath="" />
-		<None Include="..\icon.png" Pack="true" PackagePath="" />
-		<None Include="..\THIRD-PARTY-LICENSES" Pack="true" PackagePath="" />
-		<None Include="..\README.md" Pack="true" PackagePath="" />
-	</ItemGroup>
+    <ItemGroup>
+    <None Include="..\LICENSE" Pack="true" PackagePath="" />
+    <None Include="..\NOTICE" Pack="true" PackagePath="" />
+    <None Include="..\icon.png" Pack="true" PackagePath="" />
+    <None Include="..\THIRD-PARTY-LICENSES" Pack="true" PackagePath="" />
+    <None Include="..\README.md" Pack="true" PackagePath="" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="AWSSDK.Core" Version="3.7.107.9" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
-		<PackageReference Include="AWSSDK.SecurityToken" Version="3.7.103.16" />
-  	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="AWSSDK.Core" Version="3.7.400.36" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.103.16" />
+    </ItemGroup>
 </Project>

--- a/test/AWS.MSK.Auth.Test.csproj
+++ b/test/AWS.MSK.Auth.Test.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
@@ -20,7 +20,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="AWSSDK.Core" Version="3.7.107.9" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.400.36" />
     <PackageReference Include="Moq" Version="4.18.4" />
   </ItemGroup>
 


### PR DESCRIPTION
Updated `AWSSDK.Core` dependency

## Description

## Motivation and Context
Version of `AWSSDK.Core` that is used currently has credentials preempt expiry set to 5 min, while kafka credentials are signed for 15 min. Updated version has all [preempt expiry set to 15 min](https://github.com/aws/aws-sdk-net/blob/7eb6c3d000efce9c050aff77a126b5037ca9fd6b/sdk/src/Core/Amazon.Runtime/Credentials/AssumeRoleWithWebIdentityCredentials.cs#L38), which matches what is used in this library

It should fix #16 

## Testing
No more errors from Kafka client every hour (at the end of WebIdentity credentials)

## Screenshots (if appropriate)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [X] I have read the **README** document
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed

## License
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-msk-iam-sasl-signer-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement