### PR TITLE
Ensure temporary STS clients created are disposed

### DIFF
--- a/src/AWSMSKAuthTokenGenerator.cs
+++ b/src/AWSMSKAuthTokenGenerator.cs
@@ -144,7 +144,8 @@ public class AWSMSKAuthTokenGenerator
             RoleArn = roleArn
         };
 
-        var assumeRoleResponse = GetStsClient(region).AssumeRoleAsync(assumeRoleReq).GetAwaiter().GetResult();
+        using var stsClient = GetStsClient(region);
+        var assumeRoleResponse = stsClient.AssumeRoleAsync(assumeRoleReq).GetAwaiter().GetResult();
 
         var stsCredentials = assumeRoleResponse.Credentials;
 
@@ -174,7 +175,8 @@ public class AWSMSKAuthTokenGenerator
             RoleArn = roleArn
         };
 
-        var assumeRoleResponse = await GetStsClient(region).AssumeRoleAsync(assumeRoleReq);
+        using var stsClient = GetStsClient(region);
+        var assumeRoleResponse = await stsClient.AssumeRoleAsync(assumeRoleReq);
 
         var stsCredentials = assumeRoleResponse.Credentials;
 


### PR DESCRIPTION
I noticed in PR https://github.com/aws/aws-msk-iam-sasl-signer-net/pull/27 that the code was refactored to create temporary STS clients. The service clients are `IDisposable` so if the code is creating a temporary clients you need to make sure they are being disposed.

