### PR TITLE
Remove special handling for RefreshingAWSCredentials

### DIFF
--- a/test/AwsmskAuthTokenGeneratorAsyncTest.cs
+++ b/test/AwsmskAuthTokenGeneratorAsyncTest.cs
@@ -9,7 +9,6 @@ using Amazon;
 using Amazon.Runtime;
 using Amazon.SecurityToken;
 using Amazon.SecurityToken.Model;
-using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 
 namespace AWS.MSK.Auth.Tests;
@@ -72,89 +71,6 @@ public class AwsmskAuthTokenGeneratorAsyncTest
         ValidateTokenSignature(token, expiryMs);
     }
 
-    private class TestCredentials : RefreshingAWSCredentials
-    {
-        private readonly DateTime _expiration;
-
-        public TestCredentials(DateTime expiration)
-        {
-            PreemptExpiryTime = TimeSpan.FromMinutes(15);
-            _expiration = expiration;
-        }
-
-        protected override CredentialsRefreshState GenerateNewCredentials() =>
-            new(
-                new ImmutableCredentials("accessKey", "secretKey", "sessionToken", "account"),
-                _expiration);
-    }
-
-    [Fact]
-    public static async Task GenerateAuthToken_RefreshingAwsCredentials_TestInjectedCredentialsWithLongExpiration()
-    {
-        var credentials = new TestCredentials(DateTime.UtcNow.AddHours(6));
-
-        var mskAuthTokenGenerator = new AWSMSKAuthTokenGenerator();
-
-        // First store credentials
-        await mskAuthTokenGenerator.GenerateAuthTokenFromCredentialsProvider(() => credentials, RegionEndpoint.USEast1);
-        (var token, long expiryMs) = await mskAuthTokenGenerator
-            .GenerateAuthTokenFromCredentialsProvider(() => credentials, RegionEndpoint.USEast1);
-
-        ValidateTokenSignature(token, expiryMs);
-    }
-
-    [Fact]
-    public static async Task GenerateAuthToken_RefreshingAwsCredentials_TestInjectedCredentialsNotExpiringSoon()
-    {
-        DateTime now = DateTime.UtcNow;
-
-        var credentials = new TestCredentials(now.AddMinutes(29));
-
-        var mskAuthTokenGenerator = new AWSMSKAuthTokenGenerator(timeProvider: () => now);
-
-        // First store credentials
-        await mskAuthTokenGenerator.GenerateAuthTokenFromCredentialsProvider(() => credentials, RegionEndpoint.USEast1);
-        (var token, long expiryMs) = await mskAuthTokenGenerator
-            .GenerateAuthTokenFromCredentialsProvider(() => credentials, RegionEndpoint.USEast1);
-
-        ValidateTokenSignature(token, expiryMs);
-    }
-
-    [Fact]
-    public static async Task GenerateAuthToken_RefreshingAwsCredentials_TestInjectedCredentialsCloseToExpiring()
-    {
-        DateTime now = DateTime.UtcNow;
-
-        var credentials = new TestCredentials(now.AddMinutes(16));
-
-        var mskAuthTokenGenerator = new AWSMSKAuthTokenGenerator(timeProvider: () => now);
-
-        // First store credentials
-        await mskAuthTokenGenerator.GenerateAuthTokenFromCredentialsProvider(() => credentials, RegionEndpoint.USEast1);
-        (var token, long expiryMs) = await mskAuthTokenGenerator
-            .GenerateAuthTokenFromCredentialsProvider(() => credentials, RegionEndpoint.USEast1);
-
-        ValidateTokenSignature(token, expiryMs, TimeSpan.FromMinutes(8.5));
-    }
-
-    [Fact]
-    public static async Task GenerateAuthToken_RefreshingAwsCredentials_TestInjectedCredentialsAlreadyExpired()
-    {
-        DateTime now = DateTime.UtcNow;
-        TimeSpan ttl = TimeSpan.FromMinutes(10);
-
-        var credentials = new TestCredentials(now + ttl);
-
-        var mskAuthTokenGenerator = new AWSMSKAuthTokenGenerator(timeProvider: () => now);
-
-        // First store credentials
-        await mskAuthTokenGenerator.GenerateAuthTokenFromCredentialsProvider(() => credentials, RegionEndpoint.USEast1);
-        (var token, long expiryMs) = await mskAuthTokenGenerator
-            .GenerateAuthTokenFromCredentialsProvider(() => credentials, RegionEndpoint.USEast1);
-
-        ValidateTokenSignature(token, expiryMs, ttl);
-    }
-
     [Fact]
     public static async Task GenerateAuthToken_TestNoCredentials_CustomExpiryDuration()
     {
@@ -207,77 +123,6 @@ public class AwsmskAuthTokenGeneratorAsyncTest
             () => new SessionAWSCredentials("accessKey", "secretKey", "sessionToken") { Expiration = DateTime.UtcNow.AddHours(6) }, RegionEndpoint.USEast1);
 
         ValidateTokenSignature(token, expiryMs, expiryDuration);
-    }
-
-    [Fact]
-    public static async Task GenerateAuthToken_RefreshingAwsCredentials_TestInjectedCredentialsWithLongExpiration_CustomExpiryDuration()
-    {
-        var credentials = new TestCredentials(DateTime.UtcNow.AddHours(6));
-
-        TimeSpan expiryDuration = TimeSpan.FromMinutes(20);
-
-        var mskAuthTokenGenerator = new AWSMSKAuthTokenGenerator { ExpiryDuration = expiryDuration };
-
-        // First store credentials
-        await mskAuthTokenGenerator.GenerateAuthTokenFromCredentialsProvider(() => credentials, RegionEndpoint.USEast1);
-        (var token, long expiryMs) = await mskAuthTokenGenerator
-            .GenerateAuthTokenFromCredentialsProvider(() => credentials, RegionEndpoint.USEast1);
-
-        ValidateTokenSignature(token, expiryMs, expiryDuration);
-    }
-
-    [Fact]
-    public static async Task GenerateAuthToken_RefreshingAwsCredentials_TestInjectedCredentialsNotExpiringSoon_CustomExpiryDuration()
-    {
-        DateTime now = DateTime.UtcNow;
-
-        var credentials = new TestCredentials(now.AddMinutes(29));
-
-        TimeSpan expiryDuration = TimeSpan.FromMinutes(20);
-
-        var mskAuthTokenGenerator = new AWSMSKAuthTokenGenerator(timeProvider: () => now) { ExpiryDuration = expiryDuration };
-
-        // First store credentials
-        await mskAuthTokenGenerator.GenerateAuthTokenFromCredentialsProvider(() => credentials, RegionEndpoint.USEast1);
-        (var token, long expiryMs) = await mskAuthTokenGenerator
-            .GenerateAuthTokenFromCredentialsProvider(() => credentials, RegionEndpoint.USEast1);
-
-        ValidateTokenSignature(token, expiryMs, expiryDuration);
-    }
-
-    [Fact]
-    public static async Task GenerateAuthToken_RefreshingAwsCredentials_TestInjectedCredentialsCloseToExpiring_CustomExpiryDuration()
-    {
-        DateTime now = DateTime.UtcNow;
-
-        var credentials = new TestCredentials(now.AddMinutes(16));
-
-        var mskAuthTokenGenerator = new AWSMSKAuthTokenGenerator(timeProvider: () => now) { ExpiryDuration = TimeSpan.FromMinutes(20) };
-
-        // First store credentials
-        await mskAuthTokenGenerator.GenerateAuthTokenFromCredentialsProvider(() => credentials, RegionEndpoint.USEast1);
-        (var token, long expiryMs) = await mskAuthTokenGenerator
-            .GenerateAuthTokenFromCredentialsProvider(() => credentials, RegionEndpoint.USEast1);
-
-        ValidateTokenSignature(token, expiryMs, TimeSpan.FromMinutes(8.5));
-    }
-
-    [Fact]
-    public static async Task GenerateAuthToken_RefreshingAwsCredentials_TestInjectedCredentialsAlreadyExpired_CustomExpiryDuration()
-    {
-        DateTime now = DateTime.UtcNow;
-        TimeSpan ttl = TimeSpan.FromMinutes(10);
-
-        var credentials = new TestCredentials(now + ttl);
-
-        var mskAuthTokenGenerator = new AWSMSKAuthTokenGenerator(timeProvider: () => now) { ExpiryDuration = TimeSpan.FromMinutes(20) };
-
-        // First store credentials
-        await mskAuthTokenGenerator.GenerateAuthTokenFromCredentialsProvider(() => credentials, RegionEndpoint.USEast1);
-        (var token, long expiryMs) = await mskAuthTokenGenerator
-            .GenerateAuthTokenFromCredentialsProvider(() => credentials, RegionEndpoint.USEast1);
-
-        ValidateTokenSignature(token, expiryMs, ttl);
     }
 
     [Fact]


### PR DESCRIPTION
## Description
Remove special handling for `RefreshingAWSCredentials`.

## Motivation and Context
This change was introduced originally between prerelease versions to try to address an issue with credentials refreshing at expiration time, but this doesn't work for all implementations of `RefreshingAWSCredentials` per [#27#issuecomment-3190350342](https://github.com/aws/aws-msk-iam-sasl-signer-net/pull/27#issuecomment-3190350342).

## Testing
Unit tests and anecdotal tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-msk-iam-sasl-signer-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement